### PR TITLE
Potential fix for code scanning alert no. 33: Server-side request forgery

### DIFF
--- a/public/automation/sendemail-fromlocal/sendemail-local.js
+++ b/public/automation/sendemail-fromlocal/sendemail-local.js
@@ -44,6 +44,13 @@ app.post('/proxy-fetch', async (req, res) => {
         return res.status(400).json({ error: 'URL is required' });
     }
 
+    const allowList = ['https://example.com', 'https://another-allowed-domain.com'];
+    const isValidUrl = allowList.some(allowedUrl => url.startsWith(allowedUrl));
+
+    if (!isValidUrl) {
+        return res.status(400).json({ error: 'Invalid URL' });
+    }
+
     try {
         const response = await axios.get(url);
         res.json({ html: response.data });


### PR DESCRIPTION
Potential fix for [https://github.com/slowedcodinganai/deriv-static-content/security/code-scanning/33](https://github.com/slowedcodinganai/deriv-static-content/security/code-scanning/33)

To fix the SSRF vulnerability, we need to validate and sanitize the user-provided URL before using it in the `axios.get` request. The best way to do this is to use an allow-list of acceptable URLs or domains. This ensures that only predefined and safe URLs can be requested by the server.

1. Create an allow-list of acceptable URLs or domains.
2. Validate the user-provided URL against this allow-list.
3. If the URL is not in the allow-list, return an error response.
4. If the URL is valid, proceed with the `axios.get` request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
